### PR TITLE
docs: refresh README, add CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,20 @@
+language: "en"
+early_access: false
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+  path_filters:
+    - "!**/*.min.js"
+    - "!**/bin/**"
+    - "!**/obj/**"
+    - "!**/TestResults/**"
+    - "!**/*.Designer.cs"
+chat:
+  auto_reply: true

--- a/README.md
+++ b/README.md
@@ -1,40 +1,48 @@
 # NosCore.PathFinder #
 
 <p align="center">
-  <img src="https://cdn.discordapp.com/attachments/319565884454731795/426892646288457728/N2.png"/>
+  <img width="250px" src="https://github.com/NosCoreIO/NosCore.Packets/blob/15.0.1/icon.png"/>
 </p>
 
 [![NuGet](https://img.shields.io/nuget/v/NosCore.PathFinder.svg?style=flat-square)](https://www.nuget.org/packages/NosCore.PathFinder/)
-[![.NET](https://github.com/NosCoreIO/NosCore.Pathfinder/actions/workflows/dotnet.yml/badge.svg?branch=master)](https://github.com/NosCoreIO/NosCore.Pathfinder/actions/workflows/dotnet.yml)
+[![.NET](https://github.com/NosCoreIO/NosCore.PathFinder/actions/workflows/dotnet.yml/badge.svg?branch=master)](https://github.com/NosCoreIO/NosCore.PathFinder/actions/workflows/dotnet.yml)
 
 # Special Thanks for Contributions #
 <p align="left">
-<a href="https://aws.amazon.com"><img height="100px" src="https://chiefit.me/wp-content/uploads/2019/06/Amazon-Web-Services_logo835x396.png"/></a>
-<a href="https://www.navicat.com"><img height="100px" src="https://i.ibb.co/kx9WJgv/Navicat-Premium.png"/></a>
-<a href="https://www.jetbrains.com"><img height="100px" src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/1a/JetBrains_Logo_2016.svg/1200px-JetBrains_Logo_2016.svg.png"/></a>
+<a href="https://www.navicat.com"><img height="100px" src="https://user-images.githubusercontent.com/35202750/207230064-dcf23adc-9e96-4481-9a53-cd212f5bd60e.png"/></a>
 </p>
+
+## You want to contribute ? ##
+[![Discord](https://i.gyazo.com/2115a3ecb258220f5b1a8ebd8c50eb8f.png)](https://discord.gg/Eu3ETSw)
 
 ## You like our work ? ##
 <a href='https://github.com/sponsors/0Lucifer0' target='_blank'><img height='48' style='border:0px;height:46px;' src='https://i.gyazo.com/47b2ca2eb6e1ce38d02b04c410e1c82a.png' border='0' alt='Sponsor me!' /></a>
-<a href='https://ko-fi.com/A3562BQV' target='_blank'><img height='46' style='border:0px;height:46px;' src='https://az743702.vo.msecnd.net/cdn/kofi3.png?v=0' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a> 
+<a href='https://ko-fi.com/A3562BQV' target='_blank'><img height='46' style='border:0px;height:46px;' src='https://az743702.vo.msecnd.net/cdn/kofi3.png?v=0' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
 <a href='https://www.patreon.com/bePatron?u=6503887' target='_blank'><img height='46' style='border:0px;height:46px;' src='https://c5.patreon.com/external/logo/become_a_patron_button@2x.png' border='0' alt='Become a Patron!' /></a>
 
-## Achtung! ##
+## Warning! ##
 We are not responsible of any damages caused by bad usage of our source. Please before asking questions or installing this source read this readme and also do a research, google is your friend. If you mess up when installing our source because you didnt follow it, we will laugh at you. A lot.
 
 ## Instructions to contribute ##
 
-### Contribution is only possible with Visual Studio 2019 ###
-We recommend usage of : 
+### Disclaimer ###
+This project is a community project not for commercial use. The result is to learn and program together for prove the study.
+
+### Legal ###
+This is an independent and unofficial server for educational use ONLY. Using the Project might be against the TOS.
+
+### Contribution is only possible with Visual Studio 2026 ###
+We recommend usage of :
 * [Roslynator extension](https://github.com/JosefPihrt/Roslynator).
 * [Resharper](https://www.jetbrains.com/resharper/)
 
 ## GUI ##
-* A GUI is included in this project. 
+* A GUI is included in this project.
 * GUI is only working on windows and require the NosCore database to be loaded
-* GUI is not part of the shipped package. 
-* It's goal is only to visual test pathfinder with a use case 
+* GUI is not part of the shipped package.
+* Its goal is only to visual test pathfinder with a use case
 
-<p align="center">
-  <img src="https://media.discordapp.net/attachments/423344512866320385/699174285842972692/unknown.png"/>
-</p>
+## Algorithms ##
+* [Brush Fire](./documentation/BrushFireTests.Test_BrushFire.approved.md)
+* [Goal-based Pathfinder](./documentation/GoalBasedPathfinderTests.Test_GoalBasedPathfinder.approved.md)
+* [Jump Point Search](./documentation/JumpPointSearchPathfinderTests.Test_JumpPointSearchPathfinder.approved.md)


### PR DESCRIPTION
## Summary
- Remove AWS sponsor (keeping Navicat only)
- Replace German "Achtung!" with English "Warning!"
- Swap dead Discord CDN images for GitHub-hosted icons; drop dead discordapp.net GUI screenshot, link algorithm docs instead
- Fix workflow badge URL casing (`NosCore.Pathfinder` → `NosCore.PathFinder`)
- Add `.coderabbit.yaml` for open-source code review

## Test plan
- [ ] CodeRabbit picks up the new config and comments on this PR
- [ ] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)