### PR TITLE
chore: bump all NuGet packages to latest

### DIFF
--- a/src/NosCore.PathFinder.Api/NosCore.PathFinder.Api.csproj
+++ b/src/NosCore.PathFinder.Api/NosCore.PathFinder.Api.csproj
@@ -12,14 +12,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6">
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NosCore.Shared" Version="6.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
-    <PackageReference Include="YamlDotNet" Version="17.0.1" />
+    <PackageReference Include="YamlDotNet" Version="18.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NosCore.PathFinder/NosCore.PathFinder.csproj
+++ b/src/NosCore.PathFinder/NosCore.PathFinder.csproj
@@ -29,14 +29,14 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Mapster" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.6" />
-		<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.6" />
+		<PackageReference Include="Mapster" Version="10.0.11" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.11" />
 		<PackageReference Include="NosCore.Analyzers" Version="2.0.0">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Serilog" Version="4.3.1" />
+		<PackageReference Include="Serilog" Version="4.4.0" />
 		<PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
 	</ItemGroup>
 

--- a/test/NosCore.PathFinder.Tests/NosCore.PathFinder.Tests.csproj
+++ b/test/NosCore.PathFinder.Tests/NosCore.PathFinder.Tests.csproj
@@ -8,11 +8,11 @@
 
   <ItemGroup>
     <PackageReference Include="ApprovalTests" Version="7.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.6" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.3" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.7" />
     <PackageReference Include="SixLabors.Fonts" Version="2.1.3" />


### PR DESCRIPTION
- EF Core packages 10.0.6 -> 10.0.11, Npgsql.EntityFrameworkCore.PostgreSQL 10.0.1 -> 10.0.3
- Mapster 10.0.7 -> 10.0.11, Serilog 4.3.1 -> 4.4.0, YamlDotNet 17.0.1 -> 18.1.0
- Microsoft.NET.Test.Sdk 18.4.0 -> 18.8.1, MSTest 4.2.1 -> 4.3.3
- SixLabors.ImageSharp/Fonts intentionally kept on 3.x/2.x (new majors require a commercial license)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application, API, and test dependencies to newer versions.
  * Improved compatibility and stability through refreshed database, configuration, logging, mapping, and testing packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->