### PR TITLE
chore: stop dependabot proposing SixLabors majors it cannot land

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,12 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  ignore:
+    # ImageSharp 4 / Drawing 3 fail the Release build without a purchased
+    # Six Labors license, so a major bump can never go green here.
+  - dependency-name: SixLabors.ImageSharp
+    update-types: [version-update:semver-major]
+  - dependency-name: SixLabors.ImageSharp.Drawing
+    update-types: [version-update:semver-major]
+  - dependency-name: SixLabors.Fonts
+    update-types: [version-update:semver-major]


### PR DESCRIPTION
Closes #299 and #301 — neither can be merged.

### Why they cannot go green

ImageSharp 4 / Drawing 3 ship an MSBuild task that validates a Six Labors license key. It is lenient in Debug and strict in Release:

```xml
<ValidateLicenseTask ... ContinueOnError="$(Configuration.StartsWith('Debug'))" />
```

The release workflow runs `dotnet build -c Release` before `dotnet pack`, so with the bump applied:

```
SixLabors.ImageSharp.Drawing.targets(28,5): error : No Six Labors license found.
SixLabors.ImageSharp.Drawing.targets(28,5): error : Please obtain a license from https://sixlabors.com/pricing/
    1 Error(s)
```

That is a purchase, not a code fix.

Separately, Drawing 3 removes the `IImageProcessingContext` `Fill` / `DrawText` extension methods entirely and replaces them with a stateful `DrawingCanvas` built from an `ImageFrame`, taking `Brush`/`Pen` instead of `Color` and `Rectangle` instead of `RectangleF`. Every drawing call across `TestHelper`, `BrushFireTests`, `FlowFieldTests`, `GoalBasedPathfinderTests` and `JumpPointSearchPathfinderTests` would need rewriting — for test-only visualisation that already works.

### What this does

Pins the three SixLabors packages to their current major (`3.1.12` / `2.1.7` / `2.1.3`, still Apache-2.0) and tells dependabot to stop opening major bumps for them, so these PRs do not reappear daily.

Minor and patch updates still flow normally.

If the licence is ever bought, drop the `ignore` block and the migration can be done deliberately.

Verified: `dotnet build -c Release` succeeds on this branch and fails with the bump applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency updates to skip major-version upgrades for selected image-processing and font libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->